### PR TITLE
Add logic to post tweets on a communities

### DIFF
--- a/packages/shared-lib/src/index.ts
+++ b/packages/shared-lib/src/index.ts
@@ -1,1 +1,2 @@
 export * from './types/types.js';
+export * from './types/communityMapping.js';

--- a/packages/shared-lib/src/types/communityMapping.ts
+++ b/packages/shared-lib/src/types/communityMapping.ts
@@ -1,0 +1,53 @@
+/**
+ * IMPORTANT: To use Twitter Communities, you need to:
+ * 
+ * 1. Be a member of the community you want to post to
+ * 2. Have the correct permissions to post in that community
+ * 3. Get the actual Twitter Community ID from the community URL or API
+ * 
+ * To find a Twitter Community ID:
+ * - Go to the community page on Twitter/X
+ * - The ID is in the URL: https://twitter.com/i/communities/[COMMUNITY_ID]
+ * - Or use the Twitter API: GET /2/tweets/search/recent?query=conversation_id:[tweet_id]
+ * 
+ * Replace the example IDs below with actual community IDs.
+ */
+
+export interface CommunityMapping {
+  [communityName: string]: string; 
+}
+
+export const COMMUNITY_MAPPINGS: CommunityMapping = {
+  "Build in Public": "1493446837214187523",
+  "Software Engineering": "1699807431709041070"
+};
+
+/**
+ * Get Twitter Community ID from community name
+ * @param communityName - The human-readable community name
+ * @returns Twitter Community ID if found, null if not found or empty
+ */
+export function getCommunityId(communityName: string): string | null {
+  if (!communityName || communityName.trim() === '') {
+    return null;
+  }
+  
+  return COMMUNITY_MAPPINGS[communityName] || null;
+}
+
+/**
+ * Check if a community name has a valid mapping
+ * @param communityName - The human-readable community name
+ * @returns true if the community has a mapping, false otherwise
+ */
+export function hasCommunityMapping(communityName: string): boolean {
+  return getCommunityId(communityName) !== null;
+}
+
+/**
+ * Get all available community names
+ * @returns Array of all configured community names
+ */
+export function getAvailableCommunities(): string[] {
+  return Object.keys(COMMUNITY_MAPPINGS);
+} 

--- a/packages/simply-tweeted-app/src/routes/post/+page.server.ts
+++ b/packages/simply-tweeted-app/src/routes/post/+page.server.ts
@@ -1,7 +1,7 @@
 import { redirect, fail } from '@sveltejs/kit';
 import type { Actions, RequestEvent } from '@sveltejs/kit';
 import { getDbInstance } from '$lib/server/db';
-import { TweetStatus, type Tweet } from 'shared-lib';
+import { TweetStatus, type Tweet, getAvailableCommunities } from 'shared-lib';
 import { fromZonedTime } from 'date-fns-tz';
 import { log } from '$lib/server/logger.js';
 
@@ -36,8 +36,12 @@ export const load = async (event: RequestEvent) => {
 		throw redirect(303, '/login');
 	}
 	
+	// Get available communities from shared-lib
+	const availableCommunities = getAvailableCommunities();
+	
 	return {
-		session
+		session,
+		availableCommunities
 	};
 };
 

--- a/packages/simply-tweeted-app/src/routes/post/+page.svelte
+++ b/packages/simply-tweeted-app/src/routes/post/+page.svelte
@@ -2,6 +2,9 @@
 	import { enhance } from '$app/forms';
 	import { onMount, onDestroy } from 'svelte';
 	import { browser } from '$app/environment';
+	import type { PageData } from './$types';
+
+	export let data: PageData;
 
 	let tweetContent = '';
 	let scheduledDate = new Date().toISOString().split('T')[0]; // Today's date as default
@@ -132,7 +135,9 @@
 					</label>
 					<select id="community" name="community" bind:value={community} class="select select-bordered w-full">
 						<option value="">None</option>
-						<option value="build in public">Build in Public</option>
+						{#each data.availableCommunities as communityOption}
+							<option value={communityOption}>{communityOption}</option>
+						{/each}
 					</select>
 				</div>
 				


### PR DESCRIPTION
- Add static community mapping in the share-lib
- Add logic in the scheduler to post the tweet on the correct community
- Front-end now shows the community from mapping